### PR TITLE
[LGTM]ReadmeにDB設計を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ Things you may want to cover:
 ### Association
 - has_many :ship-to_addresses, dependent: :destroy
 - has_many :credit_cards, dependent: :destroy
-- has_many :seller_items, class_name: 'Item', foreign_key :"seller_id"
-- has_many :buyer_items, class_name: 'Item', foreign_key :"buyer_id"
+- has_many :seller_items, class_name: "Item", foreign_key :"seller_id"
+- has_many :buyer_items, class_name: "Item", foreign_key :"buyer_id"
 - has_one :profile, dependent: :destroy
 ※ user が消えると ship-o_address,credit-card,profile が消えることになる
 
@@ -96,8 +96,8 @@ Things you may want to cover:
 |category_id|integer|null: false, foreign_key: true|
 |brand_id|integer|foreign_key: true|
 ### Association
-- belongs_to :seller, class_name:"user", foreign_key :"seller_id"
-- belongs_to :buyer, class_name:"user", foreign_key :"buyer_id"
+- belongs_to :seller, class_name:"User", foreign_key :"seller_id"
+- belongs_to :buyer, class_name:"User", foreign_key :"buyer_id"
 - belongs_to :brand
 - belongs_to :category
 - has_many :images, dependent: :destroy

--- a/README.md
+++ b/README.md
@@ -22,3 +22,107 @@ Things you may want to cover:
 * Deployment instructions
 
 * ...
+
+# DB設計
+## usersテーブル
+|Column|Type|Options|
+|------|----|-------|
+|email|string|null: false, unique: ture|
+|password|string|null: false|
+|nickname|string|null: false|
+### Association
+- has_many :ship-to_addresses, dependent: :destroy
+- has_many :credit_cards, dependent: :destroy
+- has_many :seller_items, class_name: 'Item', :foreign_key => 'seller_id'
+- has_many :buyer_items, class_name: 'Item', :foreign_key => 'buyer_id'
+- has_one :profile, dependent: :destroy
+※ user が消えると ship-o_address,credit-card,profile が消えることになる
+
+## profilesテーブル
+|Column|Type|Options|
+|------|----|-------|
+|first_name|string|null:false|
+|family_name|string|null:false|
+|birth_year|integer|null:false|
+|birth_month|integer|null:false|
+|birth_day|integer|null:false|
+|user_id|integer|null: false, foreign_key: true|
+### Association
+- belongs_to :user
+
+## ship-to_addressesテーブル
+|Column|Type|Options|
+|------|----|-------|
+|destination_first_name|string|null: false|
+|destination_family_name|string|null: false|
+|destination_first_name_kana|string|null: false|
+|destination_family_name_kana|string|null: false|
+|post_code|integer|null: false|
+|prefectures|string|null: false|
+|city|string|null: false|
+|house_number|string|null: false|
+|building_name|string|null: false|
+|phone|integer|null: false|
+|user_id|integer|null: false, foreign_key: true|
+### Association
+- belongs_to :user
+
+## credit_cardsテーブル
+|Column|Type|Options|
+|------|----|-------|
+|card_number|integer|null:false|
+|expiration_year|integer|null:false|
+|expiration_month|integer|null:false|
+|security_code|integer|null:false|
+|user_id|integer|null: false, foreign_key: true|
+### Association
+- belongs_to :user
+
+## itemsテーブル
+|Column|Type|Options|
+|------|----|-------|
+|item_name|string|null:false|
+|text|text|null:false|
+|price|integer|null:false|
+|condtion|string|null:false|
+|prefectures|string|null: false|
+|postage_type|string|null: false|
+|days_until_shipping|string|null: false|
+|trading_status|string|null: false|
+|purchase_date|timestamp|null: false|
+|close_date|timestamp|null: false|
+|seller_id|integer|null: false, foreign_key: true|
+|buyer_id|integer|foreign_key: true|
+|category_id|integer|null: false, foreign_key: true|
+|brand_id|integer|foreign_key: true|
+### Association
+- belongs_to :seller, class_name:"user", :foreign_key => 'buyer_id'
+- belongs_to :buyer, class_name:"user", :foreign_key => 'seller_id'
+- belongs_to :brand
+- belongs_to :category
+- has_many :images, dependent: :destroy
+※ item が消えると image が消えることになる
+
+## categoriesテーブル
+|Column|Type|Options|
+|------|----|-------|
+|name|string|null:false|
+|ancestry|string|null:false|
+### Association
+- has_many :items
+※ ancestry は、gem ancestry 使用するため。
+
+## imagesテーブル
+|Column|Type|Options|
+|------|----|-------|
+|URL|string|null:false|
+|item_id|integer|null: false, foreign_key: true|
+### Association
+- belongs_to :item
+
+## barndsテーブル
+|Column|Type|Options|
+|------|----|-------|
+|name|string|null:false|
+### Association
+- has_many :items

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ Things you may want to cover:
 ### Association
 - has_many :ship-to_addresses, dependent: :destroy
 - has_many :credit_cards, dependent: :destroy
-- has_many :seller_items, class_name: "Item", foreign_key :"seller_id"
-- has_many :buyer_items, class_name: "Item", foreign_key :"buyer_id"
+- has_many :seller_items, class_name: "Item", foreign_key: "seller_id"
+- has_many :buyer_items, class_name: "Item", foreign_key: "buyer_id"
 - has_one :profile, dependent: :destroy
 ※ user が消えると ship-o_address,credit-card,profile が消えることになる
 
@@ -96,8 +96,8 @@ Things you may want to cover:
 |category_id|integer|null: false, foreign_key: true|
 |brand_id|integer|foreign_key: true|
 ### Association
-- belongs_to :seller, class_name:"User", foreign_key :"seller_id"
-- belongs_to :buyer, class_name:"User", foreign_key :"buyer_id"
+- belongs_to :seller, class_name: "User", foreign_key: "seller_id"
+- belongs_to :buyer, class_name: "User", foreign_key: "buyer_id"
 - belongs_to :brand
 - belongs_to :category
 - has_many :images, dependent: :destroy

--- a/README.md
+++ b/README.md
@@ -31,12 +31,12 @@ Things you may want to cover:
 |password|string|null: false|
 |nickname|string|null: false|
 ### Association
-- has_many :ship-to_addresses, dependent: :destroy
+- has_many :shipping_addresses, dependent: :destroy
 - has_many :credit_cards, dependent: :destroy
 - has_many :seller_items, class_name: "Item", foreign_key: "seller_id"
 - has_many :buyer_items, class_name: "Item", foreign_key: "buyer_id"
 - has_one :profile, dependent: :destroy
-※ user が消えると ship-o_address,credit-card,profile が消えることになる
+※ user が消えると shipping_address,credit-card,profile が消えることになる
 
 ## profilesテーブル
 |Column|Type|Options|
@@ -50,7 +50,7 @@ Things you may want to cover:
 ### Association
 - belongs_to :user
 
-## ship-to_addressesテーブル
+## shipping_addressesテーブル
 |Column|Type|Options|
 |------|----|-------|
 |destination_first_name|string|null: false|
@@ -81,7 +81,7 @@ Things you may want to cover:
 ## itemsテーブル
 |Column|Type|Options|
 |------|----|-------|
-|item_name|string|null:false|
+|name|string|null:false|
 |text|text|null:false|
 |price|integer|null:false|
 |condtion|string|null:false|
@@ -116,7 +116,7 @@ Things you may want to cover:
 ## imagesテーブル
 |Column|Type|Options|
 |------|----|-------|
-|URL|string|null:false|
+|url|string|null:false|
 |item_id|integer|null: false, foreign_key: true|
 ### Association
 - belongs_to :item

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Things you may want to cover:
 ### Association
 - belongs_to :item
 
-## barndsテーブル
+## brandsテーブル
 |Column|Type|Options|
 |------|----|-------|
 |name|string|null:false|

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ Things you may want to cover:
 ### Association
 - has_many :ship-to_addresses, dependent: :destroy
 - has_many :credit_cards, dependent: :destroy
-- has_many :seller_items, class_name: 'Item', :foreign_key => 'seller_id'
-- has_many :buyer_items, class_name: 'Item', :foreign_key => 'buyer_id'
+- has_many :seller_items, class_name: 'Item', foreign_key :"seller_id"
+- has_many :buyer_items, class_name: 'Item', foreign_key :"buyer_id"
 - has_one :profile, dependent: :destroy
 ※ user が消えると ship-o_address,credit-card,profile が消えることになる
 
@@ -96,8 +96,8 @@ Things you may want to cover:
 |category_id|integer|null: false, foreign_key: true|
 |brand_id|integer|foreign_key: true|
 ### Association
-- belongs_to :seller, class_name:"user", :foreign_key => 'buyer_id'
-- belongs_to :buyer, class_name:"user", :foreign_key => 'seller_id'
+- belongs_to :seller, class_name:"user", foreign_key :"seller_id"
+- belongs_to :buyer, class_name:"user", foreign_key :"buyer_id"
 - belongs_to :brand
 - belongs_to :category
 - has_many :images, dependent: :destroy
@@ -109,6 +109,7 @@ Things you may want to cover:
 |name|string|null:false|
 |ancestry|string|null:false|
 ### Association
+- has_ancestry
 - has_many :items
 ※ ancestry は、gem ancestry 使用するため。
 


### PR DESCRIPTION
# ER図

[![Image from Gyazo](https://i.gyazo.com/8692f57c0a49dcc112004cbd81e2ccfa.png)](https://gyazo.com/8692f57c0a49dcc112004cbd81e2ccfa)

# what
ReadmeにDB設計を追加

# why
フリーマーケットサイトを再現するのに必要なデーターベースを設計し、データベースを作成する。

## 備考
- 使用したER図のツール 「draw.io」
     参考したページ：https://qiita.com/tenpadrummer/items/5499ab059e1e48f5be42
     ※ アプリをダウンロードせず、WEB上で作成できるため。

- ER図を作成した際に参考したサイト
     ER図の作成方法： http://efnote.com/sql/chapter901/erd.html

     フリマアプリのDB設計：
      https://qiita.com/makiron918/items/69ddb07d3e8841250852
      https://qiita.com/oitakazuki/items/19e5ba2396624bae1057

     Gem Ancestryについて（カテゴリのテーブルに使用）：
      https://qiita.com/Rubyist_SOTA/items/49383aa7f60c42141871

     payjpについて（クレカ登録に使用）：
      https://qiita.com/dice9494/items/4aa04da1056d1f15919e

-  Associationを作成した際に参考したサイト
   class_nameについて：https://qiita.com/takeoverjp/items/bb56d6a8eae191cd3732
   dependent: :destroyについて：https://qiita.com/after4649/items/1ad419dc705f807735e0