### PR TITLE
トップページで商品一覧表示を実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@
 
 #.DS_Storeをpushしないようにする
 .DS_Store
+
+#出品画像をpushしないようにする
+public/uploads/*

--- a/app/assets/javascripts/toppage.js
+++ b/app/assets/javascripts/toppage.js
@@ -1,0 +1,6 @@
+$(function(){
+  $('.pickupContainer__itemBox__lists >li').each(function(index,element){
+    var w = $(element).width() +10
+    $('.pickupContainer__itemBox__lists').append('<li style="height:0; width:'+ w +'px; margin:0;"></li>')
+  })
+})

--- a/app/assets/javascripts/toppage.js
+++ b/app/assets/javascripts/toppage.js
@@ -4,3 +4,10 @@ $(function(){
     $('.pickupContainer__itemBox__lists').append('<li style="height:0; width:'+ w +'px; margin:0;"></li>')
   })
 })
+
+$(function(){
+  $('.itemlistmain__showbox__content__itemlists >li').each(function(index,element){
+    var w = $(element).width() +10
+    $('.itemlistmain__showbox__content__itemlists').append('<li style="height:0; width:'+ w +'px; margin:0;"></li>')
+  })
+})

--- a/app/assets/stylesheets/_header.scss
+++ b/app/assets/stylesheets/_header.scss
@@ -2,8 +2,6 @@
   padding: 0 60px;
   background-color: #fff;
   width: 100%;
-  z-index: 10;
-  box-shadow: 0 0 4px gray;
   &__inner{
     max-width: 1040px;
     width: calc(100%);

--- a/app/assets/stylesheets/_item_show.scss
+++ b/app/assets/stylesheets/_item_show.scss
@@ -32,23 +32,47 @@
       &__main {
         display: flex;
         position: relative;
-        li {
+        &__sold{
+          margin-top: 120px;
+          text-align: center;
+          width: 100%;
+          position: absolute;
+          &__text{
+            width: 75%;
+            margin: 0 auto;
+            padding: 5px;
+            font-weight:bolder;
+            font-size:40px;
+            color:#fff;
+            background:#c00;
+            opacity: 0.85;  
+          }
+        }
+      li {
           display: flex;
           flex-direction: column;
           width: 560px;
           align-items: center;
           margin: 0 auto;
           list-style: none;
+          img{
+            width: 100%;
+            height: 350px;
+            object-fit: cover;
+          }
+          
         }
         &__sub {
           display: flex;
           justify-content: center;
-          margin-top: 10px;
-          li {
+          margin: 10px;
+          img {
             display: flex;
             width: 25%;
+            height: 100px;
             margin: 0 10px 0 0;
-            list-style: none;
+            object-fit: cover;
+
             }
           }
           }
@@ -324,47 +348,3 @@
                 }
             }
           }
-        
-      
-        
-        
-      
-
-            
-          
-        
-            
-          
-
-
-      
-
-      .exhibitionBtn{
-        cursor: pointer;
-        width: 120px;
-        background: #3CCACE;
-        text-align: center;
-        border-radius: 4%;
-        bottom: 32px;
-        right: 32px;
-        position: fixed;
-        padding: 15px;
-        text-decoration: none;
-        transition: all 0.4s;
-        &:hover{
-          box-shadow:0 0 10px rgba(0,0,0,0.5);
-          background-color: darken($color: #3CCACE, $amount: 5%);
-       }
-      
-        &__text{
-          color: #fff;
-          display: block;
-          font-size: 18px;
-          margin-bottom: 5px;
-        }
-        &__icon{
-          width: 60%;
-          vertical-align: bottom;
-    
-        }
-      }

--- a/app/assets/stylesheets/_itemlists.scss
+++ b/app/assets/stylesheets/_itemlists.scss
@@ -4,7 +4,8 @@
     padding: 40px;
     margin: 0 auto;
     &__content{
-      width: 700px;
+      width: 80%;
+      max-width: 1200px;
       margin: 0 auto;
       &__titlebox{
         background-color: #fff;
@@ -38,22 +39,44 @@
         }
       }
       &__itemlists{
-        margin: 30px auto;
+        max-width: 1180px;
+        padding: 0 10px;
+        margin: 26px auto 0;
+        display:flex;
+        justify-content:center;
+        flex-wrap: wrap;
+        li{
+          color: #f8f8f8;
+        }
         .itemlist{
           width: 220px;
-          display: inline-block;
-          margin-bottom: 8px;
-          box-shadow: 0 1px 1px rgb(214, 209, 209);
-          margin-left: 7px;
-          &:hover{
-            outline: solid 1px #3CCACE;
-            transition: box-shadow 0.5s ;
-            transition: opacity 1s ;
-            box-shadow: 0 0 8px darken($color: #3CCACE, $amount: 15%);
-            opacity: 0.75;
-            
+          display: block;
+          margin: 0 5px 10px;
+          outline: 1px solid #f8f8f8;
+          box-shadow: 1px 2px 2px rgb(194, 189, 189);
+          transition: all 0.3s ; 
+          &__sold{
+            margin-top: 60px;
+            text-align: center;
+            width: 220px;
+            position: absolute;
+            &__text{
+              width: 75%;
+              margin: 0 auto;
+              padding: 5px;
+              font-weight:bolder;
+              font-size:20px;
+              color:#fff;
+              background:#c00;
+              opacity: 0.85;  
+            }
           }
-
+  
+          &:hover{
+            opacity: 0.8;
+            outline: solid 1px #3CCACE;
+            box-shadow: 0 2px 8px darken($color: #3CCACE, $amount: 15%);
+          }
           a{
             background-color: #fff;
             display: inline-block;
@@ -64,6 +87,12 @@
             height: 150px;
             overflow: hidden;
             margin: 0;
+            img{
+              width: 100%;
+              height: 150px;
+              object-fit: cover;
+              background-color: white;
+            }
           }
           &__body{
             background-color: white;
@@ -71,17 +100,41 @@
             padding: 16px;
             &__name{
               overflow: hidden;
+              width: 180px;
               line-height: 1.5;
-              font-size: 16px;
+              font-size: 15px;
               text-align: left;
+              white-space: nowrap;
+              text-overflow: ellipsis;
             }
             &__details{
+              margin-top: 5px;
               font-size: 16px;
               ul{
                 display: flex;
                 align-items: center;
                 justify-content: space-between;
+                li{
+                  color: #333;
+                }
+                li:first-of-type{
+                  color: red;
+                  font-weight: bold;
+                  .itemlist__body__details__sold{
+                    width: 100%;
+                    padding: 0 12px 0 5px;
+                    color: white;
+                    background-color: #c00;
+                    opacity: 0.85;
+                    border-top-right-radius : 1em;
+                    -webkit-border-top-right-radius: 1em;
+                    border-bottom-right-radius : 1em;
+                    -webkit-border-bottom-right-radius: 1em;
+                }
+  
+                }
               }
+
               p{
                 font-size: 10px;
                 text-align: left;
@@ -92,34 +145,5 @@
       }
     }
   }
-  .exhibitionBtn{
-    cursor: pointer;
-    width: 120px;
-    background: #3CCACE;
-    text-align: center;
-    border-radius: 4%;
-    bottom: 32px;
-    right: 32px;
-    position: fixed;
-    padding: 15px;
-    text-decoration: none;
-    transition: all 0.4s;
-    &:hover{
-      box-shadow:0 0 10px rgba(0,0,0,0.5);
-      background-color: darken($color: #3CCACE, $amount: 5%);
-   }
-  
-    &__text{
-      color: #fff;
-      display: block;
-      font-size: 18px;
-      margin-bottom: 5px;
-    }
-    &__icon{
-      width: 60%;
-      vertical-align: bottom;
-    }
-  }
-
 }
 

--- a/app/assets/stylesheets/_topPage_main.scss
+++ b/app/assets/stylesheets/_topPage_main.scss
@@ -290,6 +290,8 @@
     &__itemBox{
       margin: 0;
       padding: 0;
+      width: 100%;
+      
       &__head{
         text-align: center;
         a{
@@ -303,16 +305,39 @@
         }
       }
       &__lists{
-        width: 900px;
-        margin: 26px auto;
+        max-width: 1180px;
+        padding: 0 10px;
+        margin: 26px auto 0;
+        display:flex;
+        justify-content:center;
+        flex-wrap: wrap;
+        li{
+          color: #f8f8f8;
+        }
         .itemlist{
           width: 220px;
-          display: inline-block;
-          margin-bottom: 7px;
+          display: block;
+          margin: 0 5px 10px;
           outline: 1px solid #f8f8f8;
-          box-shadow: 0 2px 2px rgb(214, 209, 209);
+          box-shadow: 1px 2px 2px rgb(194, 189, 189);
           transition: all 0.3s ; 
-
+          &__sold{
+            margin-top: 60px;
+            text-align: center;
+            width: 220px;
+            position: absolute;
+            &__text{
+              width: 75%;
+              margin: 0 auto;
+              padding: 5px;
+              font-weight:bolder;
+              font-size:20px;
+              color:#fff;
+              background:#c00;
+              opacity: 0.85;  
+            }
+          }
+  
           &:hover{
             opacity: 0.8;
             outline: solid 1px #3CCACE;
@@ -326,9 +351,14 @@
           &__img{
             width: 220px;
             height: 150px;
-            position: relative;
             overflow: hidden;
             margin: 0;
+            img{
+              width: 100%;
+              height: 150px;
+              object-fit: cover;
+              background-color: white;
+            }
           }
           &__body{
             background-color: white;
@@ -336,17 +366,41 @@
             padding: 16px;
             &__name{
               overflow: hidden;
+              width: 180px;
               line-height: 1.5;
-              font-size: 16px;
+              font-size: 15px;
               text-align: left;
+              white-space: nowrap;
+              text-overflow: ellipsis;
             }
             &__details{
+              margin-top: 5px;
               font-size: 16px;
               ul{
                 display: flex;
                 align-items: center;
                 justify-content: space-between;
+                li{
+                  color: #333;
+                }
+                li:first-of-type{
+                  color: red;
+                  font-weight: bold;
+                  .itemlist__body__details__sold{
+                    width: 100%;
+                    padding: 0 12px 0 5px;
+                    color: white;
+                    background-color: #c00;
+                    opacity: 0.85;
+                    border-top-right-radius : 1em;
+                    -webkit-border-top-right-radius: 1em;
+                    border-bottom-right-radius : 1em;
+                    -webkit-border-bottom-right-radius: 1em;
+                }
+  
+                }
               }
+
               p{
                 font-size: 10px;
                 text-align: left;
@@ -359,7 +413,6 @@
   }
   
 }
-
 .exhibitionBtn{
   cursor: pointer;
   width: 120px;

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,10 +1,13 @@
 class ItemsController < ApplicationController
+  before_action :set_item, only: [:show, :edit, :update, :destroy]
+
+  
   def index
-    @items = Item.includes(:images).order(updated_at: "DESC") #新規登録順で表示
+    @items = Item.includes(:images).order(created_at: "DESC") #新規登録順で表示
   end
   
   def show
-    @seller = Item.find(params[:id]).seller  #sellerに対してUserデーブルを参照できるように
+    @seller = Item.find(params[:id]).seller
   end
 
   def show_itemlist
@@ -13,6 +16,7 @@ class ItemsController < ApplicationController
   def new
     render layout: 'sub_header_footer'
     @item = Item.new
+    @item.images.new
     @category_parent_array = Category.roots
   end
 
@@ -34,7 +38,6 @@ class ItemsController < ApplicationController
       render :new
     end
   end
-
 
   def card_new
   end
@@ -66,9 +69,12 @@ class ItemsController < ApplicationController
   def item_params
     params.require(:item).permit(:name, :category_id, :price, :text,
      :condtion, :postage_type, :prefectures, :days_until_shipping, :brand,
-      images_attributes: [:image, :_destroy, :id])
-      .merge(seller_id: current_user.id)
+      images_attributes: [:image, :_destroy, :id]).
+      merge(seller_id: current_user.id)
   end
 
+  def set_item
+    @item = Item.find(params[:id])
+  end
 
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,9 +1,9 @@
 class ItemsController < ApplicationController
   before_action :set_item, only: [:show, :edit, :update, :destroy]
+  before_action :set_items, only: [:index,:show_itemlist]
 
   
   def index
-    @items = Item.includes(:images).order(created_at: "DESC") #新規登録順で表示
   end
   
   def show
@@ -75,6 +75,10 @@ class ItemsController < ApplicationController
 
   def set_item
     @item = Item.find(params[:id])
+  end
+
+  def set_items
+    @items = Item.includes(:images).order(created_at: "DESC") #新規登録順で表示
   end
 
 end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -1,4 +1,4 @@
 class Image < ApplicationRecord
   belongs_to :item
-  mount_uploader :image, ImageUploader
+  mount_uploader :url, ImageUploader
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,9 +1,7 @@
 class Item < ApplicationRecord
   belongs_to :seller, class_name: "User", foreign_key: "seller_id"
-  belongs_to :buyer, class_name: "User", foreign_key: "buyer_id"
-  belongs_to :brand
+  belongs_to :buyer, class_name: "User", foreign_key: "buyer_id", optional: true
+  belongs_to :brand, optional: true
   belongs_to :category
   has_many :images, dependent: :destroy
-
-  mount_uploader :image, ImageUploader
 end

--- a/app/views/items/_itemlist.html.haml
+++ b/app/views/items/_itemlist.html.haml
@@ -1,10 +1,10 @@
 - @items.each do |item|
   %li.itemlist
-    - if item.buyer_id != nil
-      .itemlist__sold
-        .itemlist__sold__text
-          S O L D
     = link_to item_path(item.id) do
+      - if item.buyer_id != nil
+        .itemlist__sold
+          .itemlist__sold__text
+            S O L D
       .itemlist__img
         = item.images.first(1).each do |image|
           = image_tag image.url.url

--- a/app/views/items/_itemlist.html.haml
+++ b/app/views/items/_itemlist.html.haml
@@ -1,15 +1,25 @@
-.itemlist
-  .pickupContainer__itemBox__lists__list
-    = link_to "#" do
-      = image_tag img, class:"itemlist__img"
+- @items.each do |item|
+  %li.itemlist
+    - if item.buyer_id != nil
+      .itemlist__sold
+        .itemlist__sold__text
+          S O L D
+    = link_to item_path(item.id) do
+      .itemlist__img
+        = item.images.first(1).each do |image|
+          = image_tag image.url.url
       .itemlist__body
         .itemlist__body__name
-          = name
+          = item.name
         .itemlist__body__details
           %ul
-            %il 
-              = price + "円"
-            %il 
+            %li
+              - if item.buyer_id != nil
+                .itemlist__body__details__sold
+                  S O L D
+              - else
+                = "¥#{item.price.to_s(:delimited)}"
+            %li
               =icon('fa', 'star', class: 'itemlist__body__details__likeicon')
-              = like
+              0
           %p (税込み)

--- a/app/views/items/_topPage_main.html.haml
+++ b/app/views/items/_topPage_main.html.haml
@@ -102,13 +102,8 @@
         = link_to '#' do
           .pickupContainer__itemBox__head__title
             新規投稿商品
-      .pickupContainer__itemBox__lists
-        = render partial:'itemlist' ,locals: {name: "メロン", img: asset_path("pict/item-001.jpg"),price: "1000", like: "2"}
-        = render partial:'itemlist' ,locals: {name: "ソーセージ", img: asset_path("pict/item-002.jpg"),price: "5000", like: "0"}
-        = render partial:'itemlist' ,locals: {name: "さば", img: asset_path("pict/item-003.png"),price: "500", like: "0"}
-        = render partial:'itemlist' ,locals: {name: "フルーツセット", img: asset_path("pict/item-004.jpg"),price: "10000", like: "0"}
-
-
+      %ul.pickupContainer__itemBox__lists
+        = render 'itemlist'
   .pickupContainer
     .pickupContainer__head
       ピックアップブランド
@@ -118,9 +113,5 @@
           .pickupContainer__itemBox__head__title
             アーカイバ
       .pickupContainer__itemBox__lists
-        = render partial:'itemlist' ,locals: {name: "メロン", img: asset_path("pict/item-001.jpg"),price: "1000", like: "2"}
-        = render partial:'itemlist' ,locals: {name: "ソーセージ", img: asset_path("pict/item-002.jpg"),price: "5000", like: "0"}
-        = render partial:'itemlist' ,locals: {name: "さば", img: asset_path("pict/item-003.png"),price: "500", like: "0"}
-        = render partial:'itemlist' ,locals: {name: "フルーツセット", img: asset_path("pict/item-004.jpg"),price: "10000", like: "0"}
-
+        = render 'itemlist'
 = render 'exhibitionBtn'

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -5,60 +5,62 @@
         .content-top
           .item-box
             .item-box__name
-              product3
+              = @item.name
               .item-box__body
                 %ul.item-box__body__main
                   %li
-                    = link_to '/' do
-                      = image_tag asset_path("pict/item-003.png"),class:"item-box__body__main", size: '560x346'
+                    = image_tag "#{@item.images[0].url}",class:"item-box__body__main__img"
+                      - if @item.buyer_id != nil
+                      .item-box__body__main__sold
+                        .item-box__body__main__sold__text
+                          S O L D
                 %ul.item-box__body__main__sub
-                  %li
-                    = link_to '/' do
-                      = image_tag asset_path("pict/item-003.png"),class:"item-box__body__main", size: '147x87'
-                  %li
-                    = link_to '/' do
-                      = image_tag asset_path("pict/item-002.jpg"),class:"item-box__body__main", size: '147x87'
-                  %li
-                    = link_to '/' do
-                      = image_tag asset_path("pict/item-001.jpg"),class:"item-box__body__main", size: '147x87'
+                  - @item.images.each.with_index do |image|
+                    = image_tag "#{image.url}", class: "item-box-image__thumbnail"
             .item-box__body__price
-              %span ¥30000
+              %span 
+                = "¥#{@item.price.to_s(:delimited)}"
               .item-box__body__price__pricedetail
                 %span (税込)
                 %span 送料込み
             .item-box__body__price__detail
-              親譲りの無鉄砲で子供の時から損ばかりしている。小学校にいる時分学校の二階から飛び降りて一週間ほど腰を抜かした事がある。なぜそんな無闇をしたと聞く人があるかも知れぬ。別段深い理由でもない。新築の二階から首を出していたら、同級生の一人が冗談に、いくら威張っても、そこから飛び降りる事は出来まい。弱虫やーい。と囃したからである。小使に負ぶさって帰って来た時、おやじが大きな眼をして二階ぐらいから飛び降りて腰
+              = @item.text
             .item-box__body__price__detail__table
               %table
                 %tbody
                   %tr
                     %th 出品者
-                    %td hoge
+                    %td 
+                      = @seller.nickname
                   %tr
                     %th カテゴリー
-                    %td
-                      = link_to 'ベビー・キッズ','#'
-                      %br= link_to 'ベビー服(男の子用)~95cm','#'
-                      = link_to 'アウター','#'
+                    %td.blue
+                      = @item.category.parent.parent.name
+                      %br= @item.category.parent.name
+                      = @item.category.name
                   %tr
                     %th ブランド
                     %td
-                  %tr
-                    %th 商品のサイズ
-                    %td
+                      - if @item.brand_id != nil
+                        = @item.brand.name
+                      - else
+                        なし
                   %tr
                     %th 商品の状態
-                    %td 未使用に近い
+                    %td
+                      = @item.condtion
                   %tr
                     %th 配送料の負担
-                    %td 送料込み(出品者負担)
+                    %td 
+                      = @item.postage_type
                   %tr
                     %th 発送元の地域
-                    %td
-                      = link_to '岩手県','#'
+                    %td.blue
+                      = @item.prefectures
                   %tr
                     %th 発送日の目安
-                    %td 4-7日で発送
+                    %td 
+                      = @item.days_until_shipping
             .item-box__body__price__detail__optionalares
               %ul
                 %li.item-box__body__price__detail__optionalares__likebtn
@@ -85,7 +87,9 @@
                     =icon('fa', 'comment')
                   %span コメントする
         .item-box__body__purchase
-          =  link_to "この商品を購入する", purchase_items_path, class: 'item-box__body__purchase--btn'
+          - if @item.buyer_id != nil
+          - else
+            =  link_to "この商品を購入する", purchase_items_path, class: 'item-box__body__purchase--btn'
         %ul.links
           %li.link__prev
             = link_to "#", class: "prev" do

--- a/app/views/items/show_itemlist.html.haml
+++ b/app/views/items/show_itemlist.html.haml
@@ -32,13 +32,8 @@
           %li
             =link_to "その他", "#"
             
-      .itemlistmain__showbox__content__itemlists
-        = render partial:'itemlist' ,locals: {name: "メロン", img: asset_path("pict/item-001.jpg"),price: "1000", like: "2"}
-        = render partial:'itemlist' ,locals: {name: "ソーセージ", img: asset_path("pict/item-002.jpg"),price: "5000", like: "0"}
-        = render partial:'itemlist' ,locals: {name: "さば", img: asset_path("pict/item-003.png"),price: "500", like: "0"}
-        = render partial:'itemlist' ,locals: {name: "フルーツセット", img: asset_path("pict/item-004.jpg"),price: "10000", like: "0"}
+      %ul.itemlistmain__showbox__content__itemlists
+        = render 'itemlist'
 
-
-  
 = render 'exhibitionBtn'
 = render "appbanner"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -326,3 +326,226 @@ others_8 = others.children.create(name: "事務/店舗用品")
 others_8.children.create([{name: "オフィス用品一般"},{name: "オフィス家具"},{name: "店舗用品"},{name: "OA機器"},{name: "ラッピング/包装"},{name: "その他"}])
 others_9 = others.children.create(name: "その他")
 others_9.children.create([{name: "すべて"}])
+
+
+
+User.create!(
+  [
+    {
+      nickname:'アムロ', email:'test1@test.com', password: 'testtest'
+    },
+    {
+      nickname:'シャア', email:'test2@test.com', password: 'testtest'
+    }
+  ]
+)
+
+Brand.create!(
+  [
+    {
+      name:'自家製'
+    },
+    {
+      name:'夕張メロン'
+    }
+  ]
+)
+
+Item.create!(
+  [
+    {
+      name: 'メロン',
+      text: '美味しいよ！',
+      price: '1000',
+      condtion: '未使用',
+      prefectures: '神奈川県',
+      postage_type: '送料込み',
+      days_until_shipping: '1-2日で発送',
+      seller_id: '1',
+      buyer_id: '2',
+      category_id:'1288',
+      brand_id:'2',
+    },
+    {
+      name: 'ウインナー',
+      text: '酒のつまみに最適！！',
+      price: '5000',
+      condtion: '未使用',
+      prefectures: '東京都',
+      postage_type: '送料込み',
+      days_until_shipping: '3-4日で発送',
+      seller_id: '2',
+      buyer_id: '1',
+      category_id:'1291',
+      brand_id:'',
+
+    },
+    {
+      name: 'さば',
+      text: 'ランチに最適！',
+      price: '500',
+      condtion: '未使用',
+      prefectures: '東京都',
+      postage_type: '送料込み',
+      days_until_shipping: '3-4日で発送',
+      seller_id: '1',
+      buyer_id: '',
+      category_id:'1290',
+      brand_id:'1',
+
+    },
+    {
+      name: 'フルーツセット',
+      text: 'プレゼント用に個装されています。',
+      price: '10000',
+      condtion: '未使用',
+      prefectures: '青森県',
+      postage_type: '送料込み',
+      days_until_shipping: '3-4日で発送',
+      seller_id: '1',
+      buyer_id: '2',
+      category_id:'1288',
+      brand_id:'2',
+
+    }
+
+  ]
+)
+Item.create!(
+  [
+    {
+      name: 'メロン',
+      text: '美味しいよ！',
+      price: '1000',
+      condtion: '未使用',
+      prefectures: '神奈川県',
+      postage_type: '送料込み',
+      days_until_shipping: '1-2日で発送',
+      seller_id: '1',
+      buyer_id: '2',
+      category_id:'32',
+      brand_id:'2',
+    },
+    {
+      name: 'ソーセージgfdsfggdfsdffgfdsfgsdfgdfgsdf',
+      text: '酒のつまみに最適！！',
+      price: '5000',
+      condtion: '未使用',
+      prefectures: '東京都',
+      postage_type: '送料込み',
+      days_until_shipping: '3-4日で発送',
+      seller_id: '1',
+      buyer_id: '',
+      category_id:'32',
+      brand_id:'',
+
+    },
+    {
+      name: 'さば',
+      text: 'ランチに最適！',
+      price: '500',
+      condtion: '未使用',
+      prefectures: '東京都',
+      postage_type: '送料込み',
+      days_until_shipping: '3-4日で発送',
+      seller_id: '1',
+      buyer_id: '',
+      category_id:'32',
+      brand_id:'1',
+
+    },
+    {
+      name: 'フルーツセット',
+      text: 'プレゼント用に個装されています。',
+      price: '10000',
+      condtion: '未使用',
+      prefectures: '青森県',
+      postage_type: '送料込み',
+      days_until_shipping: '3-4日で発送',
+      seller_id: '2',
+      buyer_id: '',
+      category_id:'32',
+      brand_id:'2',
+
+    }
+
+  ]
+)
+Item.create!(
+  [
+    {
+      name: 'メロン 賞味期限があと1日',
+      text: 'でも美味しいよ！',
+      price: '100',
+      condtion: '未使用',
+      prefectures: '神奈川県',
+      postage_type: '送料込み',
+      days_until_shipping: '1-2日で発送',
+      seller_id: '1',
+      buyer_id: '',
+      category_id:'470',
+      brand_id:'2',
+    },
+    {
+      name: 'ソーセージ',
+      text: '酒のつまみに最適！！',
+      price: '5800',
+      condtion: '未使用',
+      prefectures: '東京都',
+      postage_type: '送料込み',
+      days_until_shipping: '3-4日で発送',
+      seller_id: '2',
+      buyer_id: '1',
+      category_id:'470',
+      brand_id:'',
+
+    },
+    {
+      name: 'パサぱさのさば',
+      text: 'ランチに最適！',
+      price: '50',
+      condtion: '未使用',
+      prefectures: '東京都',
+      postage_type: '送料込み',
+      days_until_shipping: '3-4日で発送',
+      seller_id: '1',
+      buyer_id: '',
+      category_id:'470',
+      brand_id:'1',
+
+    },
+    {
+      name: 'フルーツセット',
+      text: 'プレゼント用に個装されています。',
+      price: '10050',
+      condtion: '未使用',
+      prefectures: '青森県',
+      postage_type: '送料込み',
+      days_until_shipping: '3-4日で発送',
+      seller_id: '2',
+      buyer_id: '',
+      category_id:'470',
+      brand_id:'2',
+
+    }
+
+  ]
+)
+
+Image.create!(item_id: '1', url: open("#{Rails.root}/app/assets/images/pict/item-001.jpg"))
+Image.create!(item_id: '1', url: open("#{Rails.root}/app/assets/images/pict/pict-reason-01.jpg"))
+Image.create!(item_id: '2', url: open("#{Rails.root}/app/assets/images/pict/item-002.jpg"))
+Image.create!(item_id: '3', url: open("#{Rails.root}/app/assets/images/pict/item-003.png"))
+Image.create!(item_id: '4', url: open("#{Rails.root}/app/assets/images/pict/item-004.jpg"))
+Image.create!(item_id: '5', url: open("#{Rails.root}/app/assets/images/pict/item-001.jpg"))
+Image.create!(item_id: '5', url: open("#{Rails.root}/app/assets/images/pict/pict-reason-01.jpg"))
+Image.create!(item_id: '6', url: open("#{Rails.root}/app/assets/images/pict/item-002.jpg"))
+Image.create!(item_id: '7', url: open("#{Rails.root}/app/assets/images/pict/item-003.png"))
+Image.create!(item_id: '8', url: open("#{Rails.root}/app/assets/images/pict/item-004.jpg"))
+Image.create!(item_id: '9', url: open("#{Rails.root}/app/assets/images/pict/item-001.jpg"))
+Image.create!(item_id: '9', url: open("#{Rails.root}/app/assets/images/pict/pict-reason-01.jpg"))
+Image.create!(item_id: '10', url: open("#{Rails.root}/app/assets/images/pict/item-002.jpg"))
+Image.create!(item_id: '11', url: open("#{Rails.root}/app/assets/images/pict/item-003.png"))
+Image.create!(item_id: '12', url: open("#{Rails.root}/app/assets/images/pict/item-004.jpg"))
+
+

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -332,10 +332,10 @@ others_9.children.create([{name: "すべて"}])
 User.create!(
   [
     {
-      nickname:'アムロ', email:'test1@test.com', password: 'testtest'
+      nickname:'アムロ', email:'test1@test.com', password: 'test1111'
     },
     {
-      nickname:'シャア', email:'test2@test.com', password: 'testtest'
+      nickname:'シャア', email:'test2@test.com', password: 'test1111'
     }
   ]
 )


### PR DESCRIPTION
# what
### 以下内容を実装
1.  トップページにDBに登録された商品の商品一覧を表示  **※ 作動画像１** 
表示は新規登録順です。← Itemテーブル「created_at」で判別
2.  トップページにおいて、購入済み商品にSOLDのラベルを貼付   **※ 作動画像１** 
判別方法は、Itemテーブル「buyer_id」に値がある場合購入済みと判断。
3. トップページの商品をクリックすると、対象した商品詳細ページに遷移  **※ 作動画像２** 
商品詳細の値もDBから反映している。
4. seeds.rbにテスト用データを追加
    **テーブル：user, item, image, brand の4テーブル**

### ※ 動作を確認するには、```rails db:migrate:reset```と```rails db:reset```を実行してください。

## why
必須実装項目です。

## 実際の作動画像
- **作動画像１** 商品一覧
[![Image from Gyazo](https://i.gyazo.com/0222b3eaf0a2289dad105b61791071f3.png)](https://gyazo.com/0222b3eaf0a2289dad105b61791071f3)
---
- **作動画像２** 商品詳細
[![Image from Gyazo](https://i.gyazo.com/0227978f93a5b5c8adcef745b90693df.gif)](https://gyazo.com/0227978f93a5b5c8adcef745b90693df)