### PR TITLE
ユーザー新規登録・ログイン機能実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -82,4 +82,6 @@ gem 'payjp' #クレカ実装に使用
 gem 'fog-aws' #AWS S3への画像アップロード
 gem 'bxslider-rails' #スライドショーの作成に使用
 gem 'active_hash' #商品配送方法の選択に使用
-
+gem 'devise-i18n'
+gem 'devise-i18n-views'
+gem 'rails-i18n'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,6 +113,9 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    devise-i18n (1.9.1)
+      devise (>= 4.7.1)
+    devise-i18n-views (0.3.7)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
     erubi (1.9.0)
@@ -233,6 +236,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
+    rails-i18n (5.1.3)
+      i18n (>= 0.7, < 2)
+      railties (>= 5.0, < 6)
     railties (5.2.4.3)
       actionpack (= 5.2.4.3)
       activesupport (= 5.2.4.3)
@@ -339,6 +345,8 @@ DEPENDENCIES
   chromedriver-helper
   coffee-rails (~> 4.2)
   devise
+  devise-i18n
+  devise-i18n-views
   fog-aws
   font-awesome-sass
   haml-rails
@@ -351,6 +359,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 3.11)
   rails (~> 5.2.3)
+  rails-i18n
   sass-rails (~> 5.0)
   selenium-webdriver
   spring

--- a/app/assets/stylesheets/modules/_users.scss
+++ b/app/assets/stylesheets/modules/_users.scss
@@ -40,6 +40,12 @@ body {
         width: 400px;
         font-size: 15px;
       }
+      &--select {
+        display: inline-block;
+        height: 40px;
+        width: 200px;
+        padding: 5px 0 5px 0;
+      }
       &--remember {
         padding-top: 50px;
         text-align: center;
@@ -97,6 +103,37 @@ body {
     .transition {
       width: 600px;
       text-align: center;
+    }
+    .error {
+      padding-top: 5px;
+      text-align: center;
+      color: red;
+      font-weight: bold;
+      &__message {
+        padding-top: 5px;
+      }
+    }
+  }
+  .main-login {
+    font-size: 30px;
+    text-align: center;
+    h1 {
+      margin-top: 100px;
+    }
+    &__go-to {
+      margin: 100px 0 150px 0;
+      &--button {
+        width: 500px;
+        height: 100px;
+        background-color: #3CCACE;
+        display: inline-block;
+        line-height: 100px;
+        text-decoration: none;
+        text-align: center;
+        color: #ffffff;
+        font-weight: bold;
+        
+      }
     }
   }
 }

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -13,20 +13,19 @@ class Users::RegistrationsController < Devise::RegistrationsController
       flash.now[:alert] = @user.errors.full_messages
       render :new and return
     end
-    session["devise.regist_data"] = {user: @user.attributes}
-    session["devise.regist_data"][:user]["password"] = params[:user][:password]
+    session["devise.regist_data"] = user_params
     @shipping_address = @user.shipping_addresses.build
     render :new_shipping_address
   end
 
   def create_shipping_address
-    @user = User.new(session["devise.regist_data"]["user"])
+    @user = User.new(session["devise.regist_data"])
     @shipping_address = Shipping_address.new(address_params)
     unless @shipping_address.valid?
       flash.now[alert] = @shipping_address.errors.full_messages
-      render :new_profile and return
+      render :new_shipping_address and return
     end
-    @user.build_shipping_address(@shipping_address.attributes)
+    @user.shipping_address.build(@shipping_address.attributes)
     @user.save!
     sgin_in(:user, @user)
   end
@@ -38,7 +37,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
   end
 
   def address_params
-    params.require(:shipping_address).permit(:destination_first_name, :destination_family_name, :destination_first_name_kana, :destination_family_name_kana, :post_code, :prefectures, :city, :house_number, :building_name, :phone)
+    params.require(:shipping_address).permit(:destination_family_name, :destination_first_name, :destination_family_name_kana, :destination_first_name_kana, :post_code, :prefecture, :city, :house_number, :building_name, :phone)
   end
   
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -20,14 +20,14 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   def create_shipping_address
     @user = User.new(session["devise.regist_data"])
-    @shipping_address = Shipping_address.new(address_params)
+    @shipping_address = ShippingAddress.new(address_params)
     unless @shipping_address.valid?
       flash.now[alert] = @shipping_address.errors.full_messages
       render :new_shipping_address and return
     end
-    @user.shipping_address.build(@shipping_address.attributes)
+    @user.shipping_addresses.build(@shipping_address.attributes)
     @user.save!
-    sgin_in(:user, @user)
+    sign_in(:user, @user)
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -3,7 +3,11 @@ class UsersController < ApplicationController
     @products = Product.all
     end
   
-    def show
+  def show
   
-    end
+  end
+  
+  def destroy
+  end
+
 end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -1,4 +1,8 @@
 class Profile < ApplicationRecord
   belongs_to :user, optional: true
   validates :family_name, :first_name, :family_name_kana, :first_name_kana, :birth_year, :birth_month, :birth_day, presence: true
+  validates :family_name, :first_name, format: {with: /\A[ぁ-んァ-ン一-龥]/, message: "は全角漢字・ひらがなで入力してください"}
+  validates :birth_year, numericality: {only_integer: true, greater_than_or_equal_to: 1989, less_than_or_equal_to: 2020}
+  validates :birth_month, numericality: {only_integer: true, greater_than_or_equal_to: 1, less_than_or_equal_to: 12}
+  validates :birth_day, numericality: {only_integer: true, greater_than_or_equal_to: 1, less_than_or_equal_to: 31}
 end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -1,8 +1,8 @@
 class Profile < ApplicationRecord
   belongs_to :user, optional: true
   validates :family_name, :first_name, :family_name_kana, :first_name_kana, :birth_year, :birth_month, :birth_day, presence: true
-  validates :family_name, :first_name, format: {with: /\A[ぁ-んァ-ン一-龥]/, message: "は全角漢字・ひらがなで入力してください"}
-  validates :family_name_kana, :first_name_kana, format: {with: /\A[ぁ-んーー]+\z/, message: "は全角ひらがなで入力してください"}
+  validates :family_name, :first_name, format: {with: /\A[ぁ-んァ-ン一-龥]/, message: "は、全角漢字・ひらがなで入力してください"}
+  validates :family_name_kana, :first_name_kana, format: {with: /\A[ぁ-んーー]+\z/, message: "は、全角ひらがなで入力してください"}
   validates :birth_year, numericality: {only_integer: true, greater_than_or_equal_to: 1989, less_than_or_equal_to: 2020}
   validates :birth_month, numericality: {only_integer: true, greater_than_or_equal_to: 1, less_than_or_equal_to: 12}
   validates :birth_day, numericality: {only_integer: true, greater_than_or_equal_to: 1, less_than_or_equal_to: 31}

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -2,6 +2,7 @@ class Profile < ApplicationRecord
   belongs_to :user, optional: true
   validates :family_name, :first_name, :family_name_kana, :first_name_kana, :birth_year, :birth_month, :birth_day, presence: true
   validates :family_name, :first_name, format: {with: /\A[ぁ-んァ-ン一-龥]/, message: "は全角漢字・ひらがなで入力してください"}
+  validates :family_name_kana, :first_name_kana, format: {with: /\A[ぁ-んーー]+\z/, message: "は全角ひらがなで入力してください"}
   validates :birth_year, numericality: {only_integer: true, greater_than_or_equal_to: 1989, less_than_or_equal_to: 2020}
   validates :birth_month, numericality: {only_integer: true, greater_than_or_equal_to: 1, less_than_or_equal_to: 12}
   validates :birth_day, numericality: {only_integer: true, greater_than_or_equal_to: 1, less_than_or_equal_to: 31}

--- a/app/models/shipping_address.rb
+++ b/app/models/shipping_address.rb
@@ -1,11 +1,11 @@
 class ShippingAddress < ApplicationRecord
   belongs_to :user, optional: true
-  validates :destination_family_name, :destination_first_name, :destination_family_name_kana, :destination_first_name_kana, :post_code, :prefectures, :city, :house_number, presence: true
+  validates :destination_family_name, :destination_first_name, :destination_family_name_kana, :destination_first_name_kana, :post_code, :prefecture, :city, :house_number, presence: true
   validates :destination_family_name, :destination_first_name, format: {with: /\A[一-龥ぁ-ん]/, message: "は、全角漢字・ひらがなで入力してください"}
   validates :destination_family_name_kana, :destination_first_name_kana, format: {with: /\A[ぁ-んーー]+\z/, message: "は、全角ひらがなで入力してください"}
   validates :post_code, format: {with: /\A\d{3}[-]\d{4}\z/, message: "は、ハイフンを入れてください"}
   validates :phone, format: {with: /\A0\d{1,4}[-]\d{1,4}[-]\d{4}\z/, message: "は、ハイフン(-)を入れてください""0から始めてください"}, length: {minimum: 12}, allow_blank: true
-  enum prefectures:{
+  enum prefecture:{
     北海道:1,青森県:2,岩手県:3,宮城県:4,秋田県:5,山形県:6,福島県:7,
     茨城県:8,栃木県:9,群馬県:10,埼玉県:11,千葉県:12,東京都:13,神奈川県:14,
     新潟県:15,富山県:16,石川県:17,福井県:18,山梨県:19,長野県:20,

--- a/app/models/shipping_address.rb
+++ b/app/models/shipping_address.rb
@@ -1,7 +1,10 @@
 class ShippingAddress < ApplicationRecord
-  belongs_to :user
-  validates :user, presence: true
-  validates  :destination_first_name, :destination_family_name, :destination_first_name_kana, :destination_family_name_kana, :post_code, :prefectures, :city, :house_number, :phone, presence: true
+  belongs_to :user, optional: true
+  validates :destination_family_name, :destination_first_name, :destination_family_name_kana, :destination_first_name_kana, :post_code, :prefectures, :city, :house_number, presence: true
+  validates :destination_family_name, :destination_first_name, format: {with: /\A[一-龥ぁ-ん]/, message: "は、全角漢字・ひらがなで入力してください"}
+  validates :destination_family_name_kana, :destination_first_name_kana, format: {with: /\A[ぁ-んーー]+\z/, message: "は、全角ひらがなで入力してください"}
+  validates :post_code, format: {with: /\A\d{3}[-]\d{4}\z/, message: "は、ハイフンを入れてください"}
+  validates :phone, format: {with: /\A0\d{1,4}[-]\d{1,4}[-]\d{4}\z/, message: "は、ハイフン(-)を入れてください""0から始めてください"}, length: {minimum: 12}, allow_blank: true
   enum prefectures:{
     北海道:1,青森県:2,岩手県:3,宮城県:4,秋田県:5,山形県:6,福島県:7,
     茨城県:8,栃木県:9,群馬県:10,埼玉県:11,千葉県:12,東京都:13,神奈川県:14,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,9 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
   validates :nickname, presence: true, uniqueness: true
-
+  validates :email, uniqueness: true, format: { with: /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\Z/i}
+  validates :password, confirmation: true
+  
   has_one :profile, dependent: :destroy
   accepts_nested_attributes_for :profile
 

--- a/app/views/devise/registrations/create_shipping_address.html.haml
+++ b/app/views/devise/registrations/create_shipping_address.html.haml
@@ -1,0 +1,4 @@
+.main-login
+  %h1 登録が完了しました！
+  .main-login__go-to
+    =link_to "早速お買いものに行きましょう", root_path(@user), class: "main-login__go-to--button"

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -1,6 +1,6 @@
 .main
   %h2 会員情報入力
-  = form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
+  = form_for(@user, url: user_registration_path) do |f|
     = render "devise/shared/error_messages", resource: resource
     .field
       = f.label :ニックネーム　, class: "field--label"
@@ -33,15 +33,14 @@
           = f.label :お名前　, class: "field--label"
           = f.label :必須, class: "field--must"
           %br/
-          = f.text_field :first_name, autofocus: true, autocomplete: "first_tname", placeholder: "田中", required: "true", class: "profile__field--form"
-          = f.text_field :family_name, autofocus: true, autocomplete: "family_name", placeholder: "太郎", required: "true", class: "profile__field--form"
+          = f.text_field :family_name, autofocus: true, autocomplete: "family_name", placeholder: "田中", required: "true", class: "profile__field--form"
+          = f.text_field :first_name, autofocus: true, autocomplete: "first_tname", placeholder: "太郎", required: "true", class: "profile__field--form"
         .profile__field
           = f.label :お名前（ふりがな）, class: "field--label"
           = f.label :必須, class: "field--must"
           %br/
-          = f.text_field :first_name_kana, autofocus: true, autocomplete: "first_name_kana", placeholder: "たなか", required: "true", class: "profile__field--form"
-          = f.text_field :family_name_kana, autofocus: true, autocomplete: "family_name_kana", placeholder: "たろう", required: "true", class: "profile__field--form"
-
+          = f.text_field :family_name_kana, autofocus: true, autocomplete: "family_name_kana", placeholder: "たなか", required: "true", class: "profile__field--form"
+          = f.text_field :first_name_kana, autofocus: true, autocomplete: "first_name_kana", placeholder: "たろう", required: "true", class: "profile__field--form"
         .profile__field
           = f.label :生年月日　, class: "field--label"
           = f.label :必須, class: "field--must"
@@ -50,4 +49,4 @@
           = f.number_field :birth_month, autofocus: true, autocomplete: "birth_month", placeholder: "月", required: "true", class: "profile__field--form"
           = f.number_field :birth_day, autofocus: true, autocomplete: "birth_day", placeholder: "日", required: "true", class: "profile__field--form"
     .actions
-      = f.submit "次へ", class: "actions--btn", url: "new_shipping_address_registration_path"
+      = f.submit "次へ", class: "actions--btn"

--- a/app/views/devise/registrations/new_shipping_address.html.haml
+++ b/app/views/devise/registrations/new_shipping_address.html.haml
@@ -6,7 +6,7 @@
         - @shipping_address.errors.full_messages.each do |message|
           %li.error__message= message
   .address
-    = form_for(:shipping_address, url: create_shipping_addresses_path, method: :post) do |f|
+    = form_for(@shipping_address, url: create_shipping_addresses_path, method: :post) do |f|
       .address__field
         = f.label :お名前　, class: "field--label"
         = f.label :必須, class: "field--must"

--- a/app/views/devise/registrations/new_shipping_address.html.haml
+++ b/app/views/devise/registrations/new_shipping_address.html.haml
@@ -1,7 +1,12 @@
 .main
   %h2 商品送付先入力
+  .error
+    -if @shipping_address.errors.any?
+      %ul
+        - @shipping_address.errors.full_messages.each do |message|
+          %li.error__message= message
   .address
-    = form_for(:shipping_address) do |f|
+    = form_for(:shipping_address, url: create_shipping_addresses_path, method: :post) do |f|
       .address__field
         = f.label :お名前　, class: "field--label"
         = f.label :必須, class: "field--must"
@@ -23,7 +28,7 @@
         = f.label :都道府県　, class: "field--label"
         = f.label :必須, class: "field--must"
         %br/
-        = f.text_field :prefectures, autofocus: true, autocomplete: "prefectures", placeholder: "例) 東京都", required: "true", class: "field--form"
+        = f.select :prefecture, ShippingAddress.prefectures.keys, {prompt: "選択してください", autofocus: true, autocomplete: "prefecture"}, class: "field--select" 
       .address__field
         = f.label :市区町村　, class: "field--label"
         = f.label :必須, class: "field--must"

--- a/app/views/devise/registrations/new_shipping_address.html.haml
+++ b/app/views/devise/registrations/new_shipping_address.html.haml
@@ -48,6 +48,6 @@
         = f.label :電話番号　, class: "field--label"
         = f.label :必須, class: "field--must"
         %br/
-        = f.text_field :phone, autofocus: true, autocomplete: "phone", placeholder: "080-1234-5678", required: "true", class: "field--form"
+        = f.text_field :phone, autofocus: true, autocomplete: "phone", placeholder: "080-1234-5678", class: "field--form"
       .actions
         = f.submit "登録", class: "actions--btn", url: "#"

--- a/app/views/devise/registrations/new_shipping_address.html.haml
+++ b/app/views/devise/registrations/new_shipping_address.html.haml
@@ -46,7 +46,7 @@
         = f.text_field :building_name, autofocus: true, autocomplete: "building_name", placeholder: "例) 渋谷ビル", class: "field--form"
       .address__field
         = f.label :電話番号　, class: "field--label"
-        = f.label :必須, class: "field--must"
+        = f.label :任意, class: "field--any"
         %br/
         = f.text_field :phone, autofocus: true, autocomplete: "phone", placeholder: "080-1234-5678", class: "field--form"
       .actions

--- a/app/views/devise/shared/_error_messages.html.haml
+++ b/app/views/devise/shared/_error_messages.html.haml
@@ -1,9 +1,10 @@
-- if resource.errors.any?
-  #error_explanation
-    %h2
-      = I18n.t("errors.messages.not_saved",                 |
-        count: resource.errors.count,                       |
-        resource: resource.class.model_name.human.downcase) |
-    %ul
-      - resource.errors.full_messages.each do |message|
-        %li= message
+.error
+  - if resource.errors.any?
+    #error_explanation
+      %h2
+        = I18n.t("errors.messages.not_saved",                 |
+          count: resource.errors.count,                       |
+          resource: resource.class.model_name.human.downcase) |
+      %ul
+        - resource.errors.full_messages.each do |message|
+          %li= message

--- a/app/views/items/_header.html.haml
+++ b/app/views/items/_header.html.haml
@@ -31,9 +31,9 @@
       %ul.header-nav__right-nav
         -if user_signed_in?
           %li
-            = link_to 'マイページ', user_path(current_user),class:'header-nav__right-nav__navbtn-my'
+            = link_to 'マイページ', user_path(current_user.id),class:'header-nav__right-nav__navbtn-my'
           %li
-            = link_to 'ログアウト', destroy_user_session_path,class:'header-nav__right-nav__navbtn-out', method: :delete
+            = link_to 'ログアウト', destroy_user_session_path, method: :delete, class:'header-nav__right-nav__navbtn-out'
         -else
           %li
             = link_to 'ログイン', new_user_session_path,class:'header-nav__right-nav__navbtn-in'

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -3,7 +3,7 @@
     %a.profile-bar
       %figure.profile-icon
       %h2.profile-name
-        FURIMA
+        = current_user.nickname
       .profile-number
         .evaluation
           評価

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,7 +10,10 @@ module FleamarketSample74e
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
-
+    config.i18n.default_locale = :ja #フラッシュメッセージを日本語に
+    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
+    config.i18n.available_locales = [:ja, :en]
+    config.time_zone = 'Tokyo'
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -178,7 +178,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :validatable
   # Range for password length.
-  config.password_length = 6..128
+  config.password_length = 7..128
 
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -1,0 +1,67 @@
+ja:
+  activerecord:
+    attributes:
+      user:
+        current_password: "現在のパスワード"
+        email: "メールアドレス"
+        password: "パスワード"
+        password_confirmation: "確認用パスワード"
+        remember_me: "ログインを記憶"
+    models:
+      user: "ユーザ"
+  devise:
+    confirmations:
+      new:
+        resend_confirmation_instructions: "アカウント確認メール再送"
+    mailer:
+      confirmation_instructions:
+        action: "アカウント確認"
+        greeting: "ようこそ、%{recipient}さん!"
+        instruction: "次のリンクでメールアドレスの確認が完了します:"
+      reset_password_instructions:
+        action: "パスワード変更"
+        greeting: "こんにちは、%{recipient}さん!"
+        instruction: "誰かがパスワードの再設定を希望しました。次のリンクでパスワードの再設定が出来ます。"
+        instruction_2: "あなたが希望したのではないのなら、このメールは無視してください。"
+        instruction_3: "上のリンクにアクセスして新しいパスワードを設定するまで、パスワードは変更されません。"
+      unlock_instructions:
+        action: "アカウントのロック解除"
+        greeting: "こんにちは、%{recipient}さん!"
+        instruction: "アカウントのロックを解除するには下のリンクをクリックしてください。"
+        message: "ログイン失敗が繰り返されたため、アカウントはロックされています。"
+    passwords:
+      edit:
+        change_my_password: "パスワードを変更する"
+        change_your_password: "パスワードを変更"
+        confirm_new_password: "確認用新しいパスワード"
+        new_password: "新しいパスワード"
+      new:
+        forgot_your_password: "パスワードを忘れましたか?"
+        send_me_reset_password_instructions: "パスワードの再設定方法を送信する"
+    registrations:
+      edit:
+        are_you_sure: "本当に良いですか?"
+        cancel_my_account: "アカウント削除"
+        currently_waiting_confirmation_for_email: "%{email} の確認待ち"
+        leave_blank_if_you_don_t_want_to_change_it: "空欄のままなら変更しません"
+        title: "%{resource}編集"
+        unhappy: "気に入りません"
+        update: "更新"
+        we_need_your_current_password_to_confirm_your_changes: "変更を反映するには現在のパスワードを入力してください"
+      new:
+        sign_up: "アカウント登録"
+    sessions:
+      new:
+        sign_in: "ログイン"
+    shared:
+      links:
+        back: "戻る"
+        didn_t_receive_confirmation_instructions: "アカウント確認のメールを受け取っていませんか?"
+        didn_t_receive_unlock_instructions: "アカウントの凍結解除方法のメールを受け取っていませんか?"
+        forgot_your_password: "パスワードを忘れましたか?"
+        sign_in: "ログイン"
+        sign_in_with_provider: "%{provider}でログイン"
+        sign_up: "アカウント登録"
+    unlocks:
+      new:
+        resend_unlock_instructions: "アカウントの凍結解除方法を再送する"

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -1,14 +1,32 @@
 ja:
   activerecord:
+    errors:
+      models:
+        user:
+          attributes:
+            email:
+              taken: "は既に使用されています。"
+              blank: "が入力されていません。"
+              too_short: "は%{count}文字以上に設定して下さい。"
+              too_long: "は%{count}文字以下に設定して下さい。"
+              invalid: "は有効でありません。"
+            password:
+              taken: "は既に使用されています。"
+              blank: "が入力されていません。"
+              too_short: "は%{count}文字以上に設定して下さい。"
+              too_long: "は%{count}文字以下に設定して下さい。"
+              invalid: "は有効でありません。"
+              confirmation: "が内容とあっていません。"
     attributes:
       user:
         current_password: "現在のパスワード"
+        name: 名前
         email: "メールアドレス"
         password: "パスワード"
         password_confirmation: "確認用パスワード"
-        remember_me: "ログインを記憶"
+        remember_me: "次回から自動的にログイン"
     models:
-      user: "ユーザ"
+      user: "ユーザー"
   devise:
     confirmations:
       new:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,85 @@
+ja:
+  activerecord:
+    errors:
+      models:
+        user:
+          attributes:
+            email:
+              taken: "は既に使用されています。"
+              blank: "が入力されていません。"
+              too_short: "は%{count}文字以上に設定して下さい。"
+              too_long: "は%{count}文字以下に設定して下さい。"
+              invalid: "は有効でありません。"
+            password:
+              taken: "は既に使用されています。"
+              blank: "が入力されていません。"
+              too_short: "は%{count}文字以上に設定して下さい。"
+              too_long: "は%{count}文字以下に設定して下さい。"
+              invalid: "は有効でありません。"
+              confirmation: "が内容とあっていません。"
+    attributes:
+      user:
+        current_password: "現在のパスワード"
+        name: 名前
+        email: "メールアドレス"
+        password: "パスワード"
+        password_confirmation: "確認用パスワード"
+        remember_me: "次回から自動的にログイン"
+    models:
+      user: "ユーザー"
+  devise:
+    confirmations:
+      new:
+        resend_confirmation_instructions: "アカウント確認メール再送"
+    mailer:
+      confirmation_instructions:
+        action: "アカウント確認"
+        greeting: "ようこそ、%{recipient}さん!"
+        instruction: "次のリンクでメールアドレスの確認が完了します:"
+      reset_password_instructions:
+        action: "パスワード変更"
+        greeting: "こんにちは、%{recipient}さん!"
+        instruction: "誰かがパスワードの再設定を希望しました。次のリンクでパスワードの再設定が出来ます。"
+        instruction_2: "あなたが希望したのではないのなら、このメールは無視してください。"
+        instruction_3: "上のリンクにアクセスして新しいパスワードを設定するまで、パスワードは変更されません。"
+      unlock_instructions:
+        action: "アカウントのロック解除"
+        greeting: "こんにちは、%{recipient}さん!"
+        instruction: "アカウントのロックを解除するには下のリンクをクリックしてください。"
+        message: "ログイン失敗が繰り返されたため、アカウントはロックされています。"
+    passwords:
+      edit:
+        change_my_password: "パスワードを変更する"
+        change_your_password: "パスワードを変更"
+        confirm_new_password: "確認用新しいパスワード"
+        new_password: "新しいパスワード"
+      new:
+        forgot_your_password: "パスワードを忘れましたか?"
+        send_me_reset_password_instructions: "パスワードの再設定方法を送信する"
+    registrations:
+      edit:
+        are_you_sure: "本当に良いですか?"
+        cancel_my_account: "アカウント削除"
+        currently_waiting_confirmation_for_email: "%{email} の確認待ち"
+        leave_blank_if_you_don_t_want_to_change_it: "空欄のままなら変更しません"
+        title: "%{resource}編集"
+        unhappy: "気に入りません"
+        update: "更新"
+        we_need_your_current_password_to_confirm_your_changes: "変更を反映するには現在のパスワードを入力してください"
+      new:
+        sign_up: "アカウント登録"
+    sessions:
+      new:
+        sign_in: "ログイン"
+    shared:
+      links:
+        back: "戻る"
+        didn_t_receive_confirmation_instructions: "アカウント確認のメールを受け取っていませんか?"
+        didn_t_receive_unlock_instructions: "アカウントの凍結解除方法のメールを受け取っていませんか?"
+        forgot_your_password: "パスワードを忘れましたか?"
+        sign_in: "ログイン"
+        sign_in_with_provider: "%{provider}でログイン"
+        sign_up: "アカウント登録"
+    unlocks:
+      new:
+        resend_unlock_instructions: "アカウントの凍結解除方法を再送する"

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,85 +1,26 @@
 ja:
   activerecord:
+    attributes: 
+      profile:
+        family_name: "名字"
+        first_name: "名前"
+        family_name_kana: "名字(ふりがな)"
+        first_name_kana: "名前(ふりがな)"
+        birth_year: "年"
+        birth_month: "月"
+        birth_day: "日"
+      shipping_address:
+        destination_first_name: "名前"
+        destination_family_name: "名字"
+        destination_first_name_kana: "名前(ふりがな)"
+        destination_family_name_kana: "名字(ふりがな)"
+        post_code: "郵便番号"
+        prefecture: "都道府県"
+        city: "市区町村"
+        house_number: "番地"
     errors:
-      models:
-        user:
-          attributes:
-            email:
-              taken: "は既に使用されています。"
-              blank: "が入力されていません。"
-              too_short: "は%{count}文字以上に設定して下さい。"
-              too_long: "は%{count}文字以下に設定して下さい。"
-              invalid: "は有効でありません。"
-            password:
-              taken: "は既に使用されています。"
-              blank: "が入力されていません。"
-              too_short: "は%{count}文字以上に設定して下さい。"
-              too_long: "は%{count}文字以下に設定して下さい。"
-              invalid: "は有効でありません。"
-              confirmation: "が内容とあっていません。"
-    attributes:
-      user:
-        current_password: "現在のパスワード"
-        name: 名前
-        email: "メールアドレス"
-        password: "パスワード"
-        password_confirmation: "確認用パスワード"
-        remember_me: "次回から自動的にログイン"
-    models:
-      user: "ユーザー"
-  devise:
-    confirmations:
-      new:
-        resend_confirmation_instructions: "アカウント確認メール再送"
-    mailer:
-      confirmation_instructions:
-        action: "アカウント確認"
-        greeting: "ようこそ、%{recipient}さん!"
-        instruction: "次のリンクでメールアドレスの確認が完了します:"
-      reset_password_instructions:
-        action: "パスワード変更"
-        greeting: "こんにちは、%{recipient}さん!"
-        instruction: "誰かがパスワードの再設定を希望しました。次のリンクでパスワードの再設定が出来ます。"
-        instruction_2: "あなたが希望したのではないのなら、このメールは無視してください。"
-        instruction_3: "上のリンクにアクセスして新しいパスワードを設定するまで、パスワードは変更されません。"
-      unlock_instructions:
-        action: "アカウントのロック解除"
-        greeting: "こんにちは、%{recipient}さん!"
-        instruction: "アカウントのロックを解除するには下のリンクをクリックしてください。"
-        message: "ログイン失敗が繰り返されたため、アカウントはロックされています。"
-    passwords:
-      edit:
-        change_my_password: "パスワードを変更する"
-        change_your_password: "パスワードを変更"
-        confirm_new_password: "確認用新しいパスワード"
-        new_password: "新しいパスワード"
-      new:
-        forgot_your_password: "パスワードを忘れましたか?"
-        send_me_reset_password_instructions: "パスワードの再設定方法を送信する"
-    registrations:
-      edit:
-        are_you_sure: "本当に良いですか?"
-        cancel_my_account: "アカウント削除"
-        currently_waiting_confirmation_for_email: "%{email} の確認待ち"
-        leave_blank_if_you_don_t_want_to_change_it: "空欄のままなら変更しません"
-        title: "%{resource}編集"
-        unhappy: "気に入りません"
-        update: "更新"
-        we_need_your_current_password_to_confirm_your_changes: "変更を反映するには現在のパスワードを入力してください"
-      new:
-        sign_up: "アカウント登録"
-    sessions:
-      new:
-        sign_in: "ログイン"
-    shared:
-      links:
-        back: "戻る"
-        didn_t_receive_confirmation_instructions: "アカウント確認のメールを受け取っていませんか?"
-        didn_t_receive_unlock_instructions: "アカウントの凍結解除方法のメールを受け取っていませんか?"
-        forgot_your_password: "パスワードを忘れましたか?"
-        sign_in: "ログイン"
-        sign_in_with_provider: "%{provider}でログイン"
-        sign_up: "アカウント登録"
-    unlocks:
-      new:
-        resend_unlock_instructions: "アカウントの凍結解除方法を再送する"
+      messages:
+        record_invalid: "バリデーションに失敗しました: %{errors}。"
+        restrict_dependent_destroy:
+          has_one: "%{record}が存在しているので削除できません"
+          has_many: "%{record}が存在しているので削除できません"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
 
   devise_scope :user do
     get 'shipping_addresses', to: 'users/registrations#new_shipping_address'
-    post 'shipping_addresses', to: 'users/registrations#create_shipping_address'
+    post 'create_shipping_addresses', to: 'users/registrations#create_shipping_address'
   end
   root 'items#index'
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html

--- a/db/migrate/20200726071757_create_shipping_addresses.rb
+++ b/db/migrate/20200726071757_create_shipping_addresses.rb
@@ -5,12 +5,12 @@ class CreateShippingAddresses < ActiveRecord::Migration[5.2]
       t.string :destination_first_name,           null: false
       t.string :destination_family_name_kana,     null: false
       t.string :destination_first_name_kana,      null: false
-      t.integer :post_code,                       null: false
-      t.integer :prefectures,                      null: false
+      t.string :post_code,                       null: false
+      t.integer :prefecture,                      null: false
       t.string :city,                             null: false
       t.string :house_number,                     null: false
       t.string :building_name
-      t.integer :phone,                           null: false
+      t.string :phone
       t.references :user,                      foreign_key: true
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -74,12 +74,12 @@ ActiveRecord::Schema.define(version: 2020_08_11_132722) do
     t.string "destination_first_name", null: false
     t.string "destination_family_name_kana", null: false
     t.string "destination_first_name_kana", null: false
-    t.integer "post_code", null: false
-    t.integer "prefectures", null: false
+    t.string "post_code", null: false
+    t.integer "prefecture", null: false
     t.string "city", null: false
     t.string "house_number", null: false
     t.string "building_name"
-    t.integer "phone", null: false
+    t.string "phone"
     t.bigint "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
# What
ユーザーの新規登録・ログインに必要な機能を実装
## 作業内容
・モデルの作成と編集(migrate, models)
・コントローラー、ビュー(controller, html.haml, scss)
・日本語表示(gemfile, config>locale, config>application.rb)

# Why

## モデル
### マイグレーションファイルとモデルファイルを編集。
・user(devise)
・profile
・shipping_address
必要に応じて、それぞれのカラムにバリデーションを設定。
ex) 
名前(かな)は、ひらがなのみにしている。
emailは、@とドット(.)が必須。

## コントローラーとビュー
### registrations_controller.rb
【newアクション】
userとprofileの情報を入力できるように実装。(new.html.haml) 
↓
【createアクション】
① user,profileの情報入力でバリデーションに引っかかった場合、new.html.hamlに戻る。この時、エラーメッセージも表示する。
② バリデーションに問題なければuser, profileの入力情報を保持し、new_shipping_address.html.hamlに遷移する。（new.shipping_address.html.hamlでshipping_addressの情報を入力する。）
↓
【create_shipping_address】
① shipping_addressの情報入力でバリデーションに引っかかった場合、new_shipping_address.html.hamlに戻る。この時、エラーメッセージも表示する。
② バリデーションに問題なければ全ての入力情報を保存し、create_shipping_address.html.hamlに遷移する。（サインアップ完了）
### users_controller.rb
ログインユーザーが、ログアウトできるように、destroyアクションを定義。
### その他
ログイン画面(sessions>new.html.haml)の編集

### 画面装飾
modules>_user.scssを編集。

## エラーメッセージの表示
### 3つのgemを導入。
1. devise-i18n
2. devise-18n-views
(deviseのエラーメッセージを日本語にするためのライブラリ)
3. rails-18n
(railsのエラーメッセージを日本語にするためのライブラリ)
### config>application.rbを編集。
### devise.views.ja.ymlとja.ymlに日本語のテンプレートを挿入。

# 挙動
## 新規登録
### user, profile入力画面
https://i.gyazo.com/16eeba039f5a3e8b14cf9ff42df1e68e.gif
### shipping_address入力画面
https://i.gyazo.com/67db15e4528f7c6532ccc4d04249e0aa.gif
### ログイン中
https://i.gyazo.com/cea0669866f62265aab970ca6b76f8e8.gif
### ログアウト
https://i.gyazo.com/415ff90acaeabc805c720a9cc8342d4b.gif
### ログイン画面
https://i.gyazo.com/68a63df77d31000fb697c06438a19ec9.gif
### エラーメッセージ(バリデーション)
https://i.gyazo.com/6ec64ba0dcf892fb68e402bab43d3586.png
https://i.gyazo.com/4cb725d7a58b5748242e02ce5f3ad67a.png