### PR TITLE
サーバサイド商品詳細

### DIFF
--- a/app/assets/stylesheets/_item_show.scss
+++ b/app/assets/stylesheets/_item_show.scss
@@ -66,6 +66,7 @@
           display: flex;
           justify-content: center;
           margin: 10px;
+          flex-wrap: wrap;
           img {
             display: flex;
             width: 25%;

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -25,5 +25,12 @@ class Item < ApplicationRecord
   def like_user(user_id)
    likes.find_by(user_id: user_id)
   end
-
+  
+  def previous
+    Item.where("id < ?", self.id).order("id DESC").first
+  end
+          
+  def next
+    Item.where("id > ?", self.id).order("id ASC").first
+  end
 end

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -27,8 +27,7 @@
                 %span (税込)
                 %span 送料込み
             .item-box__body__purchase
-              - if @item.buyer_id != nil
-              - else
+              -if user_signed_in? && @user.id != @item.seller_id
                 =  link_to "この商品を購入する", purchase_items_path, class: 'item-box__body__purchase--btn'
             .item-box__body__destory
               -if user_signed_in? && @user.id == @item.seller_id
@@ -111,18 +110,32 @@
                     =icon('fa', 'comment')
                   %span コメントする
         .item-box__body__destroy
-
         %ul.links
-          %li.link__prev
-            = link_to "#", class: "prev" do
-              %i.fas.fa-chevron-left
-              %span<>
-                前の商品
+          %li.link__previous
+            - if @item.next.present?
+              = link_to item_path(@item.next) do
+                %i.fas.fa-chevron-left
+                  前の商品
+                  -# = @item.next.name
+
           %li.link__next
-            = link_to "#", class: "next" do
-              次の商品
-              %sapn<>
-              %i.fas.fa-chevron-right
+            - if @item.previous.present?
+              = link_to item_path(@item.previous) do
+                次の商品
+                -# = @item.previous.name
+                %i.fas.fa-chevron-right
+
+        -# %ul.links
+        -#   %li.link__prev
+        -#     = link_to "#", class: "prev" do
+        -#       %i.fas.fa-chevron-left
+        -#       %span<>
+        -#         前の商品
+        -#   %li.link__next
+        -#     = link_to "#", class: "next" do
+        -#       次の商品
+        -#       %sapn<>
+        -#       %i.fas.fa-chevron-right
 
 .itemlists-title
   .itemlists-title__box

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -116,26 +116,15 @@
               = link_to item_path(@item.next) do
                 %i.fas.fa-chevron-left
                   前の商品
-                  -# = @item.next.name
+
 
           %li.link__next
             - if @item.previous.present?
               = link_to item_path(@item.previous) do
                 次の商品
-                -# = @item.previous.name
                 %i.fas.fa-chevron-right
 
-        -# %ul.links
-        -#   %li.link__prev
-        -#     = link_to "#", class: "prev" do
-        -#       %i.fas.fa-chevron-left
-        -#       %span<>
-        -#         前の商品
-        -#   %li.link__next
-        -#     = link_to "#", class: "next" do
-        -#       次の商品
-        -#       %sapn<>
-        -#       %i.fas.fa-chevron-right
+
 
 .itemlists-title
   .itemlists-title__box


### PR DESCRIPTION
## what
商品出品時に登録した情報が見られるようになっている
ログアウト状態でも商品詳細ページを見ることができる
出品者にしか商品の情報編集・削除のリンクが踏めないようになっている
出品者以外にしか商品購入のリンクが踏めないようになっている
## why
商品詳細ページが必要なため。